### PR TITLE
Fixing to also add After

### DIFF
--- a/formulas/wick-base/functions/wick-service-add-dependency-systemd
+++ b/formulas/wick-base/functions/wick-service-add-dependency-systemd
@@ -22,7 +22,7 @@ wickServiceAddDependencySystemd() {
     wickDebug "Adding \"$dependency\" as a dependency of \"$service\""
 
     # Add a Wants= after the [Unit] section
-    sed -i 's/^\[\Unit\]/&\nWants='"$dependency"'/' "$overridePath"
+    sed -i 's/^\[\Unit\]/&\nWants='"$dependency"'\nAfter='"$dependency"'/' "$overridePath"
 
     # To pick up changes
     wickServiceOverride "$service"


### PR DESCRIPTION
Original I was under the impression that Wants would order services
as well, but it does not.  Wants only enables if it is not already
enabled and is required if you would like some targets to exist.