### PR TITLE
Allowing for targets and timers to be added

### DIFF
--- a/formulas/wick-base/functions/wick-service-add-dependency-systemd
+++ b/formulas/wick-base/functions/wick-service-add-dependency-systemd
@@ -13,8 +13,8 @@
 wickServiceAddDependencySystemd() {
     local dependency overridePath paths service
 
-    wickGetArgument service 0 "$@"
-    wickGetArgument dependency 1 "$@"
+    wickServiceGetNameArgumentSystemd service 0 "$@"
+    wickServiceGetNameArgumentSystemd dependency 1 "$@"
 
     wickServiceOverridePathSystemd paths "$service"
     wickArrayJoin overridePath "/" "${paths[@]}"

--- a/formulas/wick-base/functions/wick-service-get-name-argument-systemd
+++ b/formulas/wick-base/functions/wick-service-get-name-argument-systemd
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+wickServiceGetNameArgumentSystemd() {
+    local index target name
+
+    wickGetArgument target 0 "$@"
+    wickGetArgument index 1 "$@"
+
+    shift 2
+
+    wickGetArgument name "$index" "$@"
+
+    if [[ "$name" != *.target && "$name" != *.timer && "$name" != *.service ]]; then
+        name="$name.service"
+    fi
+
+    local "$target" && wickIndirect "$target" "$name"
+
+}

--- a/formulas/wick-base/functions/wick-service-make-override-systemd
+++ b/formulas/wick-base/functions/wick-service-make-override-systemd
@@ -12,7 +12,7 @@
 wickServiceMakeOverrideSystemd() {
     local overridePath paths service serviceDir
 
-    wickGetArgument service 0 "$@"
+    wickServiceGetNameArgumentSystemd service 0 "$@"
     wickServiceOverridePathSystemd paths "$service"
 
     serviceDir="${paths[0]}"

--- a/formulas/wick-base/functions/wick-service-override-path-systemd
+++ b/formulas/wick-base/functions/wick-service-override-path-systemd
@@ -23,7 +23,7 @@ wickServiceOverridePathSystemd() {
 
     wickGetArgument target 0 "$@"
     wickGetArgument service 1 "$@"
-    serviceDir="/etc/systemd/system/$service.service.d"
+    serviceDir="/etc/systemd/system/$service.d"
     fileName="override.conf"
 
     local "$target" && wickIndirectArray "$target" "$serviceDir" "$fileName"

--- a/tests/formulas/wick-base/functions/wick-service-get-name-argument-systemd.bats
+++ b/tests/formulas/wick-base/functions/wick-service-get-name-argument-systemd.bats
@@ -1,0 +1,51 @@
+#!../../../bats/bats
+
+path="formulas/wick-base/functions/wick-service-get-name-argument-systemd"
+setup() {
+    load ../../../wick-test-base
+    . "$WICK_DIR/lib/wick-indirect-array"
+    . "$WICK_DIR/lib/wick-indirect"
+    . "$WICK_DIR/lib/wick-get-arguments"
+    . "$WICK_DIR/lib/wick-get-argument"
+    . "$WICK_DIR/$path"
+}
+
+@test "$path: No extension provided" {
+    local seriveName
+
+    wickServiceGetNameArgumentSystemd serviceName 0 thing
+
+    [[ "$serviceName" == thing.service ]]
+}
+
+@test "$path: No extension but the name ends in service" {
+    local serviceName
+
+    wickServiceGetNameArgumentSystemd serviceName 0 my-service
+
+    [[ "$serviceName" == my-service.service ]]
+}
+
+@test "$path: Target extension provided" {
+    local serviceName
+
+    wickServiceGetNameArgumentSystemd serviceName 1 whatever thing.target
+
+    [[ "$serviceName" == thing.target ]]
+}
+
+@test "$path: Timer extension provided" {
+    local serviceName
+
+    wickServiceGetNameArgumentSystemd serviceName 0 thing.timer
+
+    [[ "$serviceName" == thing.timer ]]
+}
+
+@test "$path: Service extension provided" {
+    local serviceName
+
+    wickServiceGetNameArgumentSystemd serviceName 0 thing.timer
+
+    [[ "$serviceName" == thing.timer ]]
+}


### PR DESCRIPTION
Previously it would automatically add ".service" at the end of the name provided.  This functionality mimics how systemctl works.