### PR TITLE
Fixing logging issues - multiple lines and lack of data

### DIFF
--- a/formulas/apache2/functions/apache2-add-conf
+++ b/formulas/apache2/functions/apache2-add-conf
@@ -13,7 +13,7 @@ apache2AddConf() {
 
     wickGetArgument conf 0 "$@"
     wickGetOptions options "$@"
-    wickInfo "Adding Apache2 config: ${options[@]-} $conf"
+    wickInfo "Adding Apache2 config:" "${options[@]-}" "$conf"
     wickExplorer os wick-base os
 
     case "$os" in

--- a/formulas/apache2/functions/apache2-add-vhost
+++ b/formulas/apache2/functions/apache2-add-vhost
@@ -13,7 +13,7 @@ apache2AddVhost() {
 
     wickGetArgument site 0 "$@"
     wickGetOptions options "$@"
-    wickInfo "Adding Apache2 vhost: ${options[@]-} $site"
+    wickInfo "Adding Apache2 vhost:" "${options[@]-}" "$site"
     wickExplorer os wick-base os
 
     case "$os" in

--- a/lib/wick-get-url-curl
+++ b/lib/wick-get-url-curl
@@ -44,6 +44,6 @@ wickGetUrlCurl() {
         redactedArgs["$redact"]="$USERNAME:XXXXXXX"
     fi
 
-    wickDebug "wickGetUrl: ${redactedArgs[*]}"
+    wickDebug "wickGetUrl:" "${redactedArgs[@]}"
     "${args[@]}"
 }

--- a/lib/wick-get-url-wget
+++ b/lib/wick-get-url-wget
@@ -49,6 +49,6 @@ wickGetUrlWget() {
         redactedArgs["$redact"]=XXXXXXX
     fi
 
-    wickDebug "wickGetUrl: ${redactedArgs[*]}"
+    wickDebug "wickGetUrl:" "${redactedArgs[@]}"
     "${args[@]}"
 }


### PR DESCRIPTION
Multiple line issue, before:

    DEBUG: curl
    DEBUG: -option
    DEBUG: -another=option
    DEBUG: http://example.com

Multiple lines after:

    DEBUG: curl -option -another=option http://example.com

This stemmed from using ${array[*]} inside of a string.  When used that
way, the array is joined by the first character of IFS.  With strict
mode, IFS is set to "\n\t", so the messages were joined up by newlines.

Lack of data before:

    INFO: Adding virtual host stuff  config

Lack of data after:

    INFO: Adding virtual host stuff arrayElement1 arrayElement2 config

The variable was being inserted incorrectly.