### PR TITLE
Wick strict run subshell

### DIFF
--- a/bin/wick-run-formula
+++ b/bin/wick-run-formula
@@ -47,7 +47,7 @@ wickRunFormula() {
     # an if statement) then it behaves as if -e is not set. See
     # https://github.com/tests-always-included/wick/blob/master/doc/contexts-that-disable-exit-on-error.md
     # for more information.
-    wickStrictRun result eval "(wickStrictMode ; . $formula)"
+    wickStrictRun result eval ". $formula"
 
     if [[ "$result" -ne 0 ]]; then
         echo "FAILURE DETECTED"

--- a/lib/wick-strict-run
+++ b/lib/wick-strict-run
@@ -22,27 +22,30 @@
 #       wickInfo "some-string was not found"
 #   fi
 #
-#   # If the user would like to use strict mode for the
-#   # command they are running they can use a subshell
-#   # and manually enable wickStrictMode.
-#   wickStrictRun result eval "(wickStrictMode; command)"
-#
 # Returns nothing.
 wickStrictRun() {
-    local dest result setOptions
+    local dest restoreErrors result
 
     dest=$1
     shift
-    setOptions=$-
+    # Gathering current settings and traps for ERR
+    # so we can restore them at will later.
+    restoreErrors="set \"-$-\";$(trap -p ERR)"
+
+    # Disabling errors only for executing this subshell.  For once,
+    # we don't want it to exit if the subshell fails and we don't
+    # want it logging a stack trace just for this line.  We do,
+    # however, want strict mode enabled inside the subshell.
     set +eE
-    # Turning off the error trap for this context.  I don't
-    # need the stack trace for the line the command was executed
-    # on.
     trap "" ERR
-    "$@"
+
+    (
+        eval "$restoreErrors"
+        "$@"
+    )
+
     result=$?
-    set -"$setOptions"
-    trap 'wickStrictModeFail $?' ERR
+    eval "$restoreErrors"
 
     local "$dest" && wickIndirect "$dest" "$result"
 }


### PR DESCRIPTION
Changing to automatically run in subshell, enable wickStrictMode and reset ERR traps to what they were before running the command.