### PR TITLE
Skipping chkconfig if it is not there.

### DIFF
--- a/formulas/wick-base/functions/wick-service-make-override-sysv
+++ b/formulas/wick-base/functions/wick-service-make-override-sysv
@@ -13,7 +13,7 @@
 # Returns true on success, non-zero if the file exists and should not be
 # clobbered.
 wickServiceMakeOverrideSysv() {
-    local dest force label lsb service src value
+    local dest force label lsb pattern service src value
 
     wickGetOption force force "$@"
     wickGetArgument service 0 "$@"
@@ -34,7 +34,14 @@ wickServiceMakeOverrideSysv() {
     fi
 
     lsb=$(sed '0,/^### BEGIN INIT INFO/ d; /^### END INIT INFO/,$ d' "$src")
-    grep '^# chkconfig:' "$src" | head -n 1 > "$dest"
+    pattern='^# chkconfig:'
+
+    if grep -q "$pattern" "$src"; then
+        grep "$pattern" "$src" | head -n 1 > "$dest"
+    else
+        touch "$dest"
+    fi
+
     echo '### BEGIN INIT INFO' >> "$dest"
 
     for label in Provides Default-Start Default-Stop Required-Start Required-Stop Should-Start Should-Stop; do

--- a/formulas/wick-base/functions/wick-service-make-override-sysv
+++ b/formulas/wick-base/functions/wick-service-make-override-sysv
@@ -13,7 +13,7 @@
 # Returns true on success, non-zero if the file exists and should not be
 # clobbered.
 wickServiceMakeOverrideSysv() {
-    local chkConf dest force label lsb service src value
+    local dest force label lsb service src value
 
     wickGetOption force force "$@"
     wickGetArgument service 0 "$@"
@@ -36,13 +36,9 @@ wickServiceMakeOverrideSysv() {
     lsb=$(sed '0,/^### BEGIN INIT INFO/ d; /^### END INIT INFO/,$ d' "$src")
 
     # Ignoring the absence of the chkconfig line.
-    chkConf=$(grep '^# chkconfig:' "$src" || :)
-
-    if [[ -n "$chkConf" ]]; then
-        echo "$chkConf" | head -n 1 > "$dest"
-    else
-        touch "$dest"
-    fi
+    {
+        grep '^# chkconfig:' "$src" || :
+    } | head -n 1 > "$dest"
 
     echo '### BEGIN INIT INFO' >> "$dest"
 

--- a/formulas/wick-base/functions/wick-service-make-override-sysv
+++ b/formulas/wick-base/functions/wick-service-make-override-sysv
@@ -13,7 +13,7 @@
 # Returns true on success, non-zero if the file exists and should not be
 # clobbered.
 wickServiceMakeOverrideSysv() {
-    local dest force label lsb pattern service src value
+    local chkConf dest force label lsb service src value
 
     wickGetOption force force "$@"
     wickGetArgument service 0 "$@"
@@ -34,10 +34,12 @@ wickServiceMakeOverrideSysv() {
     fi
 
     lsb=$(sed '0,/^### BEGIN INIT INFO/ d; /^### END INIT INFO/,$ d' "$src")
-    pattern='^# chkconfig:'
 
-    if grep -q "$pattern" "$src"; then
-        grep "$pattern" "$src" | head -n 1 > "$dest"
+    # Ignoring the absence of the chkconfig line.
+    chkConf=$(grep '^# chkconfig:' "$src" || :)
+
+    if [[ -z "$chkConf" ]]; then
+        echo "$chkConf" | head -n 1 > "$dest"
     else
         touch "$dest"
     fi

--- a/formulas/wick-base/functions/wick-service-make-override-sysv
+++ b/formulas/wick-base/functions/wick-service-make-override-sysv
@@ -38,7 +38,7 @@ wickServiceMakeOverrideSysv() {
     # Ignoring the absence of the chkconfig line.
     chkConf=$(grep '^# chkconfig:' "$src" || :)
 
-    if [[ -z "$chkConf" ]]; then
+    if [[ -n "$chkConf" ]]; then
         echo "$chkConf" | head -n 1 > "$dest"
     else
         touch "$dest"


### PR DESCRIPTION
Ran into a case where the chkconfig line was not there in our
consul init file and I wanted to set an override for Dolphin.