### PR TITLE
Bug fixes

### DIFF
--- a/formulas/wick-base/explorers/os
+++ b/formulas/wick-base/explorers/os
@@ -62,6 +62,19 @@ if [[ -f /etc/arch-release ]]; then
     exit
 fi
 
+# Check os-release files for ID
+if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+elif [[ -f /usr/lib/os-release ]]; then
+    . /usr/lib/os-release
+fi
+# ID is lowercase distro name and defaults to "linux" if missing
+if [[ -n "${ID-}" ]] && [[ "$ID" != "linux" ]]; then
+    wickDebug "os ID: $ID"
+    echo "$ID"
+    exit
+fi
+				    
 if wickCommandExists lsb_release; then
     distributor=$(lsb_release -s -i 2>&1)
     wickDebug "Distributor: $distributor"

--- a/lib/wick-get-iface-ip
+++ b/lib/wick-get-iface-ip
@@ -33,7 +33,17 @@ wickGetIfaceIp() {
         allInterfaces=true
     fi
 
-    if wickCommandExists ifconfig; then
+    # Works for systemd distros
+    if wickCommandExists networkctl; then
+        cmd=(networkctl status)
+
+	if [[ -n "$interface" ]]; then
+	    cmd[${#cmd[@]}]="$interface"
+	fi
+
+       # FIXME: Unfortunately, IPv4 only
+       list=( $("${cmd[@]}" 2>/dev/null | grep -oP "\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b") )
+    elif wickCommandExists ifconfig; then
         cmd=(ifconfig -v)
 
         if [[ -n "$interface" ]]; then


### PR DESCRIPTION
Two bug fixes:
- fix issue where docker host is different Linux type than the guest container which breaks os detection
- add networkctl support for systemd distros that don't have the "ip" or "ifconfig" commands installed

@kyle-long : I was told these fixes might be of interest to you.
