### PR TITLE
Wait for lock.

### DIFF
--- a/formulas/add-repository/functions/add-repository-apt
+++ b/formulas/add-repository/functions/add-repository-apt
@@ -24,5 +24,7 @@ addRepositoryApt() {
     fi
 
     wickInfo "Adding repository $repo"
-    add-apt-repository --yes "$repo" && apt-get update
+    add-apt-repository --yes "$repo"
+    wickWaitFor 600 wickIsAptAvailable
+    apt-get update
 }

--- a/formulas/update-packages/depends
+++ b/formulas/update-packages/depends
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+wickFormula wick-base

--- a/formulas/update-packages/run
+++ b/formulas/update-packages/run
@@ -24,7 +24,10 @@ case "$OS" in
         ;;
 
     debian|ubuntu)
-        apt-get update && apt-get upgrade -y
+        wickWaitFor 600 wickIsAptAvailable
+        apt-get update
+        wickWaitFor 600 wickIsAptAvailable
+        apt-get upgrade -y
         ;;
 
     *)

--- a/formulas/wick-base/README.md
+++ b/formulas/wick-base/README.md
@@ -183,6 +183,18 @@ This searches the file for a section with the same name and removes it. Next it 
 Returns 0 on success, 1 on argument validation errors.
 
 
+`wickIsAptAvailable()`
+----------------------
+
+Checks whether Apt and Dpkg type applications are running.
+
+Examples
+
+    wickIsAptAvailable
+
+Returns 0 when no Apt or Dpkg type applications are found running. Returns >0 when an Apt or Dpkg type application is found running.
+
+
 `wickMakeDir()`
 ---------------
 

--- a/formulas/wick-base/functions/wick-is-apt-available
+++ b/formulas/wick-base/functions/wick-is-apt-available
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Checks whether Apt and Dpkg type applications are running.
+#
+# Examples
+#
+#   wickIsAptAvailable
+#
+# Returns 0 when no Apt or Dpkg type applications are found running.
+# Returns > 0 when an Apt or Dpkg type application is found running.
+wickIsAptAvailable() {
+    pidof dpkg > /dev/null 2>&1 && return 1
+    pidof apt-get > /dev/null 2>&1 && return 2
+    pidof synaptic > /dev/null 2>&1 && return 3
+    pidof apt > /dev/null 2>&1 && return 4
+    pidof aptitude > /dev/null 2>&1 && return 5
+
+    return 0
+}

--- a/formulas/wick-base/functions/wick-package-apt
+++ b/formulas/wick-base/functions/wick-package-apt
@@ -18,6 +18,7 @@ wickPackageApt() {
 
     case "$state" in
         clean)
+            wickWaitFor 600 wickIsAptAvailable
             apt-get clean
             ;;
 
@@ -32,10 +33,12 @@ wickPackageApt() {
             ;;
 
         install)
+            wickWaitFor 600 wickIsAptAvailable
             apt-get install -y "$@"
             ;;
 
         uninstall)
+            wickWaitFor 600 wickIsAptAvailable
             apt-get purge -y "$@"
             ;;
 


### PR DESCRIPTION
Sometimes the updates don't work e.g. when the onboot security updates are taking place. Adding wickWaitfor statements to retry for up to 10 minutes to run the update/upgrade.
