### PR TITLE
set hostname fails on ubuntu

### DIFF
--- a/formulas/hostname/files/set-hostname
+++ b/formulas/hostname/files/set-hostname
@@ -85,8 +85,18 @@ wickDebug "Setting hostname to $full"
 #
 reload=false
 
-if replaceInFile /etc/sysconfig/network HOSTNAME=$full HOSTNAME=; then
-    reload=true
+if [[ -f /etc/hostname ]]; then
+    if [[ "$(cat /etc/hostname)" !=  "$host" ]]; then
+        wickDebug "Setting /etc/hostname to $host"
+        echo "$host" > /etc/hostname
+        reload=true
+    fi
+fi
+
+if [[ -f /etc/sysconfig/network ]]; then
+    if replaceInFile /etc/sysconfig/network HOSTNAME=$full HOSTNAME=; then
+        reload=true
+    fi
 fi
 
 if replaceInFile /etc/sysctl.conf kernel.hostname=$host kernel.hostname=; then


### PR DESCRIPTION
Tested and looking good in centos and ubuntu:

```
ubuntu@docker-192-168-69-53:~$ hostname -s
docker-192-168-69-53
ubuntu@docker-192-168-69-53:~$ hostname
docker-192-168-69-53
ubuntu@docker-192-168-69-53:~$ hostname -f
docker-192-168-69-53.node.consul
ubuntu@docker-192-168-69-53:~$ 
```
```
[centos@docker-192-168-65-3 ~]$ hostname -s
docker-192-168-65-3
[centos@docker-192-168-65-3 ~]$ hostname 
docker-192-168-65-3
[centos@docker-192-168-65-3 ~]$ hostname -f
docker-192-168-65-3.node.consul
[centos@docker-192-168-65-3 ~]$ 
```