### PR TITLE
Fixing wickMakeUser bug

### DIFF
--- a/formulas/wick-base/README.md
+++ b/formulas/wick-base/README.md
@@ -293,7 +293,7 @@ Examples
     wickMakeUser fidian
 
     # Update that same user with a new shell.
-    wickMakeUser --shell=/bin/zsh
+    wickMakeUser fidian --shell=/bin/zsh
 
     # Create a system account that can't login.  It is used to
     # run a special server that's installed in /opt/myserver.
@@ -305,7 +305,7 @@ Examples
     # --daemon enables --no-skel --system and disables --move-home
     wickMakeUser --daemon --home=/opt/myserver --name="MyServer" myserver
 
-Returns zero on success, one if required arguments are not passed in.
+Returns 0 on success, 1 if required arguments are not passed in.
 
 
 `wickPackage()`

--- a/formulas/wick-base/README.md
+++ b/formulas/wick-base/README.md
@@ -285,14 +285,14 @@ Create or manage a user on the system.
 * --shell=SHELL - Optional; set a shell that isn't the default for the user.
 * --system      - Optional; uses a lower user ID when available when creating the user.
 
-For consistency, the home directory is always created if it does not exist and the ownership of the home directory is always set to `USERNAME:USERNAME`.
+For consistency, the home directory is always created if it does not exist and the ownership of the home directory is always set to `USERNAME:USERNAME`. If the given user already exists and no options are given `usermod` will not be run.
 
-Examples:
+Examples
 
-    # Create a normal user
+    # Create a normal user.
     wickMakeUser fidian
 
-    # Update that same user with a new shell
+    # Update that same user with a new shell.
     wickMakeUser --shell=/bin/zsh
 
     # Create a system account that can't login.  It is used to
@@ -305,7 +305,7 @@ Examples:
     # --daemon enables --no-skel --system and disables --move-home
     wickMakeUser --daemon --home=/opt/myserver --name="MyServer" myserver
 
-Returns true on success.
+Returns zero on success, one if required arguments are not passed in.
 
 
 `wickPackage()`

--- a/formulas/wick-base/functions/wick-make-user
+++ b/formulas/wick-base/functions/wick-make-user
@@ -72,12 +72,12 @@ wickMakeUser() {
 
         if [[ -n "$setHome" ]]; then
             args[${#args[@]}]=-d
-            args[${#args[@]}]="$setHome"
+            args[${#args[@]}]=$setHome
         fi
 
         if [[ -n "$setName" ]]; then
             args[${#args[@]}]=-c
-            args[${#args[@]}]="$setName"
+            args[${#args[@]}]=$setName
         fi
 
         if [[ -n "$noSkelFlag" ]]; then
@@ -86,7 +86,7 @@ wickMakeUser() {
 
         if [[ -n "$setShell" ]]; then
             args[${#args[@]}]=-s
-            args[${#args[@]}]="$setShell"
+            args[${#args[@]}]=$setShell
         fi
 
         if [[ -n "$systemFlag" ]]; then
@@ -102,7 +102,7 @@ wickMakeUser() {
 
         if [[ -n "$setHome" ]]; then
             args[${#args[@]}]=-d
-            args[${#args[@]}]="$setHome"
+            args[${#args[@]}]=$setHome
         fi
 
         if [[ -n "$moveHomeFlag" ]]; then
@@ -111,16 +111,16 @@ wickMakeUser() {
 
         if [[ -n "$setName" ]]; then
             args[${#args[@]}]=-c
-            args[${#args[@]}]="$setName"
+            args[${#args[@]}]=$setName
         fi
 
         if [[ -n "$setShell" ]]; then
             args[${#args[@]}]=-s
-            args[${#args[@]}]="$setShell"
+            args[${#args[@]}]=$setShell
         fi
 
         if [[ "${#args[@]}" -gt 1 ]]; then
-            args[${#args[@]}]="$username"
+            args[${#args[@]}]=$username
             wickDebug "Command:" "${args[@]}"
             "${args[@]}"
         else

--- a/formulas/wick-base/functions/wick-make-user
+++ b/formulas/wick-base/functions/wick-make-user
@@ -25,7 +25,7 @@
 #   wickMakeUser fidian
 #
 #   # Update that same user with a new shell.
-#   wickMakeUser --shell=/bin/zsh
+#   wickMakeUser fidian --shell=/bin/zsh
 #
 #   # Create a system account that can't login.  It is used to
 #   # run a special server that's installed in /opt/myserver.
@@ -37,7 +37,7 @@
 #   # --daemon enables --no-skel --system and disables --move-home
 #   wickMakeUser --daemon --home=/opt/myserver --name="MyServer" myserver
 #
-# Returns zero on success, one if required arguments are not passed in.
+# Returns 0 on success, 1 if required arguments are not passed in.
 wickMakeUser() {
     local args daemonFlag moveHomeFlag noSkelFlag passwd setHome setName setShell systemFlag userhome username
 

--- a/formulas/wick-base/functions/wick-make-user
+++ b/formulas/wick-base/functions/wick-make-user
@@ -16,13 +16,15 @@
 #
 # For consistency, the home directory is always created if it does not exist
 # and the ownership of the home directory is always set to `USERNAME:USERNAME`.
+# If the given user already exists and no options are given `usermod` will not
+# be run.
 #
-# Examples:
+# Examples
 #
-#   # Create a normal user
+#   # Create a normal user.
 #   wickMakeUser fidian
 #
-#   # Update that same user with a new shell
+#   # Update that same user with a new shell.
 #   wickMakeUser --shell=/bin/zsh
 #
 #   # Create a system account that can't login.  It is used to
@@ -35,7 +37,7 @@
 #   # --daemon enables --no-skel --system and disables --move-home
 #   wickMakeUser --daemon --home=/opt/myserver --name="MyServer" myserver
 #
-# Returns true on success.
+# Returns zero on success, one if required arguments are not passed in.
 wickMakeUser() {
     local args daemonFlag moveHomeFlag noSkelFlag passwd setHome setName setShell systemFlag userhome username
 
@@ -50,11 +52,12 @@ wickMakeUser() {
 
     if [[ -z "$username" ]]; then
         wickError "You must specify a username for wickMakeUser"
+
         return 1
     fi
 
-    # Set reasonable defaults for daemons
-    if [[ ! -z "$daemonFlag" ]]; then
+    # Set reasonable defaults for daemons.
+    if [[ -n "$daemonFlag" ]]; then
         moveHomeFlag=""
         noSkelFlag=true
         setShell=/bin/false
@@ -67,26 +70,26 @@ wickMakeUser() {
         wickInfo "Creating user: $username"
         args=(useradd)
 
-        if [[ ! -z "$setHome" ]]; then
+        if [[ -n "$setHome" ]]; then
             args[${#args[@]}]=-d
-            args[${#args[@]}]=$setHome
+            args[${#args[@]}]="$setHome"
         fi
 
-        if [[ ! -z "$setName" ]]; then
+        if [[ -n "$setName" ]]; then
             args[${#args[@]}]=-c
-            args[${#args[@]}]=$setName
+            args[${#args[@]}]="$setName"
         fi
 
-        if [[ ! -z "$noSkelFlag" ]]; then
+        if [[ -n "$noSkelFlag" ]]; then
             args[${#args[@]}]=-M
         fi
 
-        if [[ ! -z "$setShell" ]]; then
+        if [[ -n "$setShell" ]]; then
             args[${#args[@]}]=-s
-            args[${#args[@]}]=$setShell
+            args[${#args[@]}]="$setShell"
         fi
 
-        if [[ ! -z "$systemFlag" ]]; then
+        if [[ -n "$systemFlag" ]]; then
             args[${#args[@]}]=-r
         fi
 
@@ -97,28 +100,32 @@ wickMakeUser() {
         wickInfo "Altering user: $username"
         args=(usermod)
 
-        if [[ ! -z "$setHome" ]]; then
+        if [[ -n "$setHome" ]]; then
             args[${#args[@]}]=-d
-            args[${#args[@]}]=$setHome
+            args[${#args[@]}]="$setHome"
         fi
 
-        if [[ ! -z "$moveHomeFlag" ]]; then
+        if [[ -n "$moveHomeFlag" ]]; then
             args[${#args[@]}]=-m
         fi
 
-        if [[ ! -z "$setName" ]]; then
+        if [[ -n "$setName" ]]; then
             args[${#args[@]}]=-c
-            args[${#args[@]}]=$setName
+            args[${#args[@]}]="$setName"
         fi
 
-        if [[ ! -z "$setShell" ]]; then
+        if [[ -n "$setShell" ]]; then
             args[${#args[@]}]=-s
-            args[${#args[@]}]=$setShell
+            args[${#args[@]}]="$setShell"
         fi
 
-        args[${#args[@]}]=$username
-        wickDebug "Command:" "${args[@]}"
-        "${args[@]}"
+        if [[ "${#args[@]}" -gt 1 ]]; then
+            args[${#args[@]}]="$username"
+            wickDebug "Command:" "${args[@]}"
+            "${args[@]}"
+        else
+            wickInfo "Provided user exists and no options were given, continuing on without altering user."
+        fi
     fi
 
     userhome=$(getent passwd "$username" | cut -d : -f 6)


### PR DESCRIPTION
If `wickMakeUser` is called with a user that exists and no options are given it simply runs `usermod <user>` which blows up. I fixed this. If no options are given it simply logs a message and moves on.