### PR TITLE
Fixing the dnsmasq --protect-dns option

### DIFF
--- a/formulas/dnsmasq/README.md
+++ b/formulas/dnsmasq/README.md
@@ -3,21 +3,21 @@ Dnsmasq
 
 Installs dnsmasq and adds it as a nameserver.
 
-* --start - Starts the service.  If not specified, the service will not be running when the formula finishes.
+* --start       - Starts the service. If not specified, the service will not be running when the formula finishes.
 
-* --protect-dns - Runs the protect-dns-resolver-config file, which will rewrite the part of dhclient that overwrites /etc/resolv.conf. A full box can prevent /etc/resolv.conf from being overwritten fully, which makes it very difficult to ssh onto the box.
+* --protect-dns - Adds the contents of [protect-dns-resolver-config](files/protect-dns-resolver-config) to `/etc/dhcp/dhclient-enter-hooks` which prevents `resolv.conf` from being corrupt by `make_resolv_conf`. One situation where this occurs is if there is insufficient disc space remaining to write a new `resolv.conf`. This is only a problem if there is a service running as root and can access and ultimately fill the system reserved portion of disc space.
 
 When `--start` is used, `/etc/resolv.conf` is updated to use dnsmasq. Without `--start`, the nameserver entry is not added.  It would be assumed that either the machine will be rebooted (and thus dnsmasq's nameserver entry would be added with the dhclient hook) or `/etc/resolv.conf` will be updated at a later time when dnsmasq is enabled.
 
 Examples
 
-    wickFormula dnsmasq
-
+    # Installs dnsmasq and starts it immediately.
     wickFormula dnsmasq --start
 
+    # Installs dnsmasq and prevents the corruption of resolv.conf.
     wickFormula dnsmasq --protect-dns
 
-Returns nothing
+Returns nothing.
 
 
 `dnsmasqAdd()`

--- a/formulas/dnsmasq/README.md
+++ b/formulas/dnsmasq/README.md
@@ -11,6 +11,9 @@ When `--start` is used, `/etc/resolv.conf` is updated to use dnsmasq. Without `-
 
 Examples
 
+    # Installs dnsmasq.
+    wickFormula dnsmasq
+
     # Installs dnsmasq and starts it immediately.
     wickFormula dnsmasq --start
 

--- a/formulas/dnsmasq/files/protect-dns-resolver-config
+++ b/formulas/dnsmasq/files/protect-dns-resolver-config
@@ -12,9 +12,8 @@
 # This is sh not Bash!
 
 # Replacing calls to `make_resolv_conf` with a call to our override function.
-# Our override function only calls the original make_resolv_conf if it can
-# make a copy of the original. Making sure we preserve any indentation while
-# also avoiding an endless line `make_resolv_conf_override` calls.
+# In reference to the command, we are making sure to preserve any indentation
+# while also avoiding an endless line of `make_resolv_conf_override` calls.
 sed -i 's/\(^ *\)make_resolv_conf *$/\1make_resolv_conf_override || make_resolv_conf/' /sbin/dhclient-script
 
 # Attempts to make a copy of the original `resolv.conf`. If it cannot
@@ -31,7 +30,7 @@ sed -i 's/\(^ *\)make_resolv_conf *$/\1make_resolv_conf_override || make_resolv_
 make_resolv_conf_override() {
     resolvConf=$(readlink -f "/etc/resolv.conf" 2>/dev/null) || resolvConf="/etc/resolv.conf"
     temp="${resolvConf}.tmp"
-    cat "$resolvConf" > "$temp"
+    cp "$resolvConf" "$temp"
 
     # dhclient does not safely overwrite the resolv.conf file. Appears
     # they are just banking on the 5% system reservation.

--- a/formulas/dnsmasq/files/protect-dns-resolver-config
+++ b/formulas/dnsmasq/files/protect-dns-resolver-config
@@ -1,28 +1,52 @@
-#!/usr/bin/env bash
+#!/bin/sh
+# This script should be added to `/etc/dhcp/dhclient-enter-hooks`. This will
+# protect against the very rare occurrence that a service running as root
+# completely fills the disc including the system reserve. This will cause
+# `make_resolv_conf` to fail to build a proper temporary `resolv.conf`. Instead
+# of just stopping, `dhclient` just continues on and calls `change_resolv_conf`,
+# which outputs the incomplete contents of the temporary `resolv.conf` to
+# `/etc/resolv.conf`. This results in an empty or partial `resolv.conf`.
+# Fortunately, `change_resolv_conf` checks the exit code of the `echo` command
+# and only invalidates the DNS cache if it is 0. Unfortunately, you are still
+# left with a corrupt `resolv.conf`.
+# This is sh not Bash!
 
-eval "$(
-    funcBody=$(declare -f make_resolv_conf)
-    echo "${funcBody/make_resolv_conf/make_resolv_conf_real}"
-);"
+# Replacing calls to `make_resolv_conf` with a call to our override function.
+# Our override function only calls the original make_resolv_conf if it can
+# make a copy of the original. Making sure we preserve any indentation while
+# also avoiding an endless line `make_resolv_conf_override` calls.
+sed -i 's/\(^ *\)make_resolv_conf *$/\1make_resolv_conf_override || make_resolv_conf/' /sbin/dhclient-script
 
-make_resolv_conf() {
+# Attempts to make a copy of the original `resolv.conf`. If it cannot
+# `make_resolv_conf` is not called. If `make_resolv_conf` fails the original
+# `resolv.conf` is restored.
+#
+# Examples
+#
+#   # Calls through to make_resolv_conf if a copy of made.
+#   # Restores resolv.conf with the copy if make_resolv_conf fails.
+#   make_resolv_conf_override
+#
+# Returns nothing.
+make_resolv_conf_override() {
     resolvConf=$(readlink -f "/etc/resolv.conf" 2>/dev/null) || resolvConf="/etc/resolv.conf"
+    temp="${resolvConf}.tmp"
+    cat "$resolvConf" > "$temp"
 
-    # Exit immediately if resolve.conf can't be copied, so that resolve.conf
-    # won't be overwritten by dhclient.
-    if ! cp "$resolvConf" "${resolvConf}.tmp"; then
-        return 1
+    # dhclient does not safely overwrite the resolv.conf file. Appears
+    # they are just banking on the 5% system reservation.
+    # If we cannot cat a copy of it we cannot overwrite it.
+    if [ $? -eq 0 ]; then
+        # This is the easiest and most surefire way to capture the output. Writing
+        # the output to a file may not work if the machine is completely full.
+        output=$(make_resolv_conf 2>&1)
+
+        if [ -n "$output" ]; then
+            echo "$output" >&2
+            mv -f "$temp" > "$resolvConf"
+        fi
     fi
 
-    # This is the easiest and most surefire way to capture the output. Writing
-    # the output to a file may not work if the machine is completely full.
-    makeResolvConfOutput=$(make_resolve_conf_real 2>&1)
-
-    if [ -n "$makeResolvConfOutput" ]; then
-        echo "$makeResolfConfOutput" >&2
-        mv "${resolvConf}.tmp" "$resolvConf"
-    else
-        rm "${resolvConf}.tmp"
-    fi
+    rm -f "$temp"
 }
 

--- a/formulas/dnsmasq/run
+++ b/formulas/dnsmasq/run
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 # Installs dnsmasq and adds it as a nameserver.
 #
-# --start - Starts the service.  If not specified, the service will not be
-#           running when the formula finishes.
+# --start       - Starts the service. If not specified, the service will not be
+#                 running when the formula finishes.
 #
-# --protect-dns - Runs the protect-dns-resolver-config file, which will rewrite
-#                 the part of dhclient that overwrites /etc/resolv.conf. A full
-#                 box can prevent /etc/resolv.conf from being overwritten fully,
-#                 which makes it very difficult to ssh onto the box.
+# --protect-dns - Adds the contents of [protect-dns-resolver-config](files/protect-dns-resolver-config)
+#                 to `/etc/dhcp/dhclient-enter-hooks` which prevents
+#                 `resolv.conf` from being corrupt by `make_resolv_conf`. One
+#                 situation where this occurs is if there is insufficient
+#                 disc space remaining to write a new `resolv.conf`.
+#                 This is only a problem if there is a service running as root
+#                 and can access and ultimately fill the system reserved
+#                 portion of disc space.
 #
 # When `--start` is used, `/etc/resolv.conf` is updated to use dnsmasq.
 # Without `--start`, the nameserver entry is not added.  It would be assumed
@@ -17,14 +21,16 @@
 #
 # Examples
 #
-#   wickFormula dnsmasq
-#
+#   # Installs dnsmasq and starts it immediately.
 #   wickFormula dnsmasq --start
 #
+#   # Installs dnsmasq and prevents the corruption of resolv.conf.
 #   wickFormula dnsmasq --protect-dns
 #
-# Returns nothing
-wickGetOption start start "$@"
+# Returns nothing.
+declare start protectDns
+
+wickGetOption start --start "$@"
 wickGetOption protectDns --protect-dns "$@"
 wickPackage dnsmasq
 wickMakeDir /etc/dnsmasq.d/
@@ -37,7 +43,6 @@ wickService force-state dnsmasq "$start"
 # The normal, one-line method may not work in all situations.
 # http://www.fidian.com/problems-only-tyler-has/dhclient-not-honoring-prepend-config
 # wickSetConfigLine /etc/dhcp/dhclient.conf "prepend domain-name-servers 127.0.0.1;" "prepend domain-name-servers"
-
 if [[ ! -f /etc/dhcp/dhclient-enter-hooks ]]; then
     echo "#!/bin/sh" > /etc/dhcp/dhclient-enter-hooks
     chmod 755 /etc/dhcp/dhclient-enter-hooks

--- a/formulas/dnsmasq/run
+++ b/formulas/dnsmasq/run
@@ -21,6 +21,9 @@
 #
 # Examples
 #
+#   # Installs dnsmasq.
+#   wickFormula dnsmasq
+#
 #   # Installs dnsmasq and starts it immediately.
 #   wickFormula dnsmasq --start
 #


### PR DESCRIPTION
Removing Bash syntax, adding more elaborate explanations, and overriding make_resolv_conf by searching and replacing calls to it with calls to my override function.