### PR TITLE
Explorer should only output amazon.

### DIFF
--- a/formulas/wick-base/explorers/machine-type
+++ b/formulas/wick-base/explorers/machine-type
@@ -32,7 +32,7 @@ fi
 # Amazon's network can fail so we try the detection a couple times
 # shellcheck disable=SC2034
 for I in {1..3}; do
-    if wickGetUrl --timeout=1 http://169.254.169.254/latest/meta-data/ami-id; then
+    if wickGetUrl --timeout=1 http://169.254.169.254/latest/meta-data/ami-id &>/dev/null; then
         wickDebug "Detected Amazon (url ami-id)" || exit $?
         echo "amazon"
 


### PR DESCRIPTION
It was also outputing the ami id causing test to fail, combined with an addition to allow for non vns amazon builds this is a critical bug fix. Consul now tying to eth0 instead of tun0 which causes consul to break.

Explorer output and resulting consul interface before this fix:

    amazon-ebs: DEBUG: Explorer stdout:
    amazon-ebs: DEBUG: ami-efbee39camazon
    amazon-ebs: DEBUG: Explorer stderr:
    amazon-ebs: DEBUG: ami-efbee39camazon
    amazon-ebs: DEBUG: End of explorer output
    amazon-ebs: DEBUG: Explorer success
    amazon-ebs: INFO: ***** Base image
    amazon-ebs: INFO: *****     Name: logstash
    amazon-ebs: INFO: *****     VNS3 Role: logstash
    amazon-ebs: INFO: *****     Consul Role: agent
    amazon-ebs: INFO: *****     Consul iface: eth0

And after:

    amazon-ebs: DEBUG: Explorer stdout:
    amazon-ebs: DEBUG: amazon
    amazon-ebs: DEBUG: Explorer stderr:
    amazon-ebs: DEBUG: amazon
    amazon-ebs: DEBUG: End of explorer output
    amazon-ebs: DEBUG: Explorer success
    amazon-ebs: INFO: ***** Base image
    amazon-ebs: INFO: *****     Name: logstash
    amazon-ebs: INFO: *****     VNS3 Role: logstash
    amazon-ebs: INFO: *****     Consul Role: agent
    amazon-ebs: INFO: *****     Consul iface: tun0

