### PR TITLE
Shorter array notation + documentation update

### DIFF
--- a/bin/wick-help
+++ b/bin/wick-help
@@ -14,6 +14,7 @@ wickHelp() {
 
     if [[ "${#WICK_COMMAND_HELP[@]}" -eq 0 ]]; then
         echo "No commands defined"
+
         return
     fi
 

--- a/doc/bash-strict-mode.md
+++ b/doc/bash-strict-mode.md
@@ -97,7 +97,7 @@ The better option is to ignore only the return code for `myProgram`.  That way e
 With `set -u` enabled, you are unable to use positional parameters that are not defined.  Let's say you have a function that will `echo` the first parameter.
 
     # This is the old function
-    function echoFirst() {
+    echoFirst() {
         echo $1
     }
 
@@ -105,21 +105,21 @@ When you run `echoFirst` with no arguments, the above will fail.  To adapt this 
 
     # You can default to an empty value, which is similar to how Bash
     # would interpret this without set -u
-    function echoFirst() {
-        echo ${1-}
+    echoFirst() {
+        echo "${1-}"
     }
 
     # Alternately you can test for the number of arguments
-    function echoFirst() {
+    echoFirst() {
         if [[ $# -gt 0 ]]; then
-            echo $1
+            echo "$1"
         fi
     }
 
 Strangely enough, `$@` will never give an error even in strict mode.
 
-    # This always works
-    function showArgs() {
+    # This always works, but it does pass an empty argument to echo.
+    showArgs() {
         echo "$@"
     }
 
@@ -151,18 +151,27 @@ When working with arrays, Bash exhibits some odd behavior and it varies based on
     # cause problems with other functions.
     echo "All elements in the array:" "${ARR[@]-}"
 
+    # Option 3 (best)
+    # Use some interesting Bash syntax that translates into "If ARR is set
+    # then use the value of the expanded array".  Please note that there
+    # is intentionally no surrounding quotes!
+    echo "All elements in the array:" ${ARR[@]+"${ARR[@]}"}
+
 
 ### Appending to an array
 
 There are several ways to append values to an array.
 
-    # Define an array
+    # Define an array.
     ARR=()
 
-    # Does not work when ARR is empty
+    # Does not work when ARR is empty.
     ARR=("${ARR[@]}" "another value")
 
-    # Use this instead
+    # Bash 4.3 and newer, which Wick does not use.
+    ARR+=("another value")
+
+    # Use this instead.  Works in Bash 3 and newer.
     ARR[${#ARR[@]}]="another value"
 
 
@@ -177,7 +186,7 @@ We used to be able to run a command and catch its return code.
         echo "There was a failure that will need to get handled"
     fi
 
-With the strict mode in place it is much harder to do that.  One option is to use `set +e` and then `set -e` again.  There is a function, `wickStrictRun` that does this for you.  A full description is in [library functions](../lib/README.md).
+With the strict mode in place it is much harder to do that.  One option is to use `set +e` and then `set -e` again.  You also need to worry about traps.  There is a function, `wickStrictRun` that does this for you.  A full description is in [library functions](../lib/README.md).
 
     # Use this syntax
     wickStrictRun RESULT someCommandThatMayFail

--- a/formulas/selinux/README.md
+++ b/formulas/selinux/README.md
@@ -25,13 +25,7 @@ Returns success (0) when SELinux is installed and enabled.
 
 Examples
 
-    # Convoluted, but necessary because of strict mode and newer Bash.
-    # See doc/contexts-that-disable-exit-on-error.md
-    local result
-
-    wickStrictRun result selinuxIsEnabled
-
-    if [[ "$result" -eq 0 ]]; then
+    if selinuxIsEnabled; then
         wickWarn "This does not work well with SELinux enabled"
     fi
 

--- a/formulas/wick-base/README.md
+++ b/formulas/wick-base/README.md
@@ -128,7 +128,7 @@ Returns true on success.
 `bashFormulaTemplate()`
 -----------------------
 
-Run a Bash shell script as a template.
+Run a Bash shell script as a template.  Sources the file.
 
 Examples
 

--- a/lib/wick-array-filter
+++ b/lib/wick-array-filter
@@ -51,11 +51,6 @@ wickArrayFilter() {
         shift
     done
 
-    if [[ ${#result[@]} -eq 0 ]]; then
-        local "$target" && wickIndirectArray "$target"
-
-        return
-    fi
-
-    local "$target" && wickIndirectArray "$target" "${result[@]}"
+    # shellcheck disable=SC2068
+    local "$target" && wickIndirectArray "$target" ${result[@]+"${result[@]}"}
 }

--- a/lib/wick-get-arguments
+++ b/lib/wick-get-arguments
@@ -34,11 +34,6 @@ wickGetArguments() {
         shift
     done
 
-    if [[ ${#args[@]} -eq 0 ]]; then
-        local "$target" && wickIndirectArray "$target"
-
-        return
-    fi
-
-    local "$target" && wickIndirectArray "$target" "${args[@]}"
+    # shellcheck disable=SC2068
+    local "$target" && wickIndirectArray "$target" ${args[@]+"${args[@]}"}
 }

--- a/lib/wick-get-iface-ip
+++ b/lib/wick-get-iface-ip
@@ -55,13 +55,8 @@ wickGetIfaceIp() {
     fi
 
     if [[ "$allInterfaces" == true ]]; then
-        if [[ ${#list[@]} -eq 0 ]]; then
-            local "$target" && wickIndirectArray "$target"
-
-            return 0
-        fi
-
-        local "$target" && wickIndirectArray "$target" "${list[@]}"
+        # shellcheck disable=SC2068
+        local "$target" && wickIndirectArray "$target" ${list[@]+"${list[@]}"}
 
         return 0
     fi

--- a/lib/wick-get-options
+++ b/lib/wick-get-options
@@ -34,11 +34,6 @@ wickGetOptions() {
         shift
     done
 
-    if [[ "${#options[@]}" -eq 0 ]]; then
-        local "$target" && wickIndirectArray "$target"
-
-        return
-    fi
-
-    local "$target" && wickIndirectArray "$target" "${options[@]}"
+    # shellcheck disable=SC2068
+    local "$target" && wickIndirectArray "$target" ${options[@]+"${options[@]}"}
 }

--- a/lib/wick-indirect-array
+++ b/lib/wick-indirect-array
@@ -22,14 +22,12 @@
 #           [[ "${#value[@]}" -lt 5 ]] && value[${#value[@]}]=$file
 #       done
 #
-#       # Be careful when `set -u` is enabled
-#       if [[ ${#value[@]} -eq 0 ]]; then
-#           local "$1" && wickIndirectArray "$1"
-#
-#           return
-#       fi
-#
-#       local "$1" && wickIndirectArray "$1" "${value[@]}"
+#       # Be careful when `set -u` is enabled.  This next line is EXTREMELY
+#       # IMPORTANT to get right.  The variable at the end is intentionally
+#       # not quoted so this works with empty arrays and arrays that contain
+#       # empty strings.
+#       # shellcheck disable=SC2068
+#       local "$1" && wickIndirectArray "$1" ${value[@]+"${value[@]}"}
 #   }
 #
 #   files=""

--- a/lib/wick-port-up
+++ b/lib/wick-port-up
@@ -20,6 +20,7 @@
 #
 #   if ! wickWaitFor 120 wickPortUp TCP 80; then
 #       echo "Tried to wait for 2 minutes but nothing listened on port 80"
+#
 #       exit 1
 #   fi
 #

--- a/lib/wick-string-split
+++ b/lib/wick-string-split
@@ -31,11 +31,6 @@ wickStringSplit() {
 
     result[${#result[@]}]=$str
 
-    if [[ "${#result[@]}" -gt 0 ]]; then
-        local "$target" && wickIndirectArray "$target" "${result[@]}"
-
-        return
-    fi
-
-    local "$target" && wickIndirectArray "$target"
+    # shellcheck disable=SC2068
+    local "$target" && wickIndirectArray "$target" ${result[@]+"${result[@]}"}
 }

--- a/lib/wick-test-for-argument-count
+++ b/lib/wick-test-for-argument-count
@@ -27,7 +27,7 @@ wickTestForArgumentCount() {
 
     wickGetArguments args "$@" || return $?
 
-    # Add 1 to the count in order to compensate for the count itself.
+    #: Add 1 to the count in order to compensate for the count itself.
     count=$((count + 1))
 
     if [[ "${#args[@]}" -ne "$count" ]]; then

--- a/lib/wick-wait-for
+++ b/lib/wick-wait-for
@@ -62,9 +62,9 @@ wickWaitFor() {
 
         sleepProcess=$!
 
-        # Delay until one of the processes finish
-        # Avoid "wait -n" because older bash does not support it
-        # This also hides a "Terminated" message
+        #: Delay until one of the processes finish
+        #: Avoid "wait -n" because older bash does not support it
+        #: This also hides a "Terminated" message
         result=0
         wait "$latchProcess" > /dev/null 2>&1 || result=$?
 


### PR DESCRIPTION
Old:

    if [[ "${#arrayName[@]}" -gt 0 ]]; then
        local "$target" && wickIndirectArray "$target" "${arrayName[@]}"

        return 0
    fi

    local "$target" && wickIndirectArray "$target"

New:

    local "$target" && wickIndirectArray "$target" ${arrayName[@]+"${arrayName[@]}"}

Syntax works with:

* Empty arrays
* Arrays that contain values with spaces
* Arrays that contain empty values
* Arrays with normal, boring values