### PR TITLE
Adding reset.

### DIFF
--- a/formulas/wick-base/functions/wick-service-override
+++ b/formulas/wick-base/functions/wick-service-override
@@ -24,5 +24,6 @@ wickServiceOverride() {
         systemctl daemon-reload || return $?
     else
         chkconfig --override "$service" || return $?
+        chkconfig "$service" reset || return $?
     fi
 }


### PR DESCRIPTION
Without the reset the order of the init scripts is not amended. There is also a 'resetpriorities' option but I figured there may be other things that where changed. Thanks to @quantumew for finding the fix.