### PR TITLE
IFS= appears to merge all elements

### DIFF
--- a/doc/argument-processing.md
+++ b/doc/argument-processing.md
@@ -108,7 +108,7 @@ Imagine a function that will consume one argument and pass the rest to another f
 
         # Remove the first item from the list. The IFS notation is to
         # ensure this works even in bash 3, regardless of IFS settings.
-        IFS= ARGS=("${ARGS[@]:1}")
+        IFS=" " ARGS=("${ARGS[@]:1}")
 
         # Pass the remaining arguments to another function
         setupDir "${ARGS[@]}"

--- a/formulas/wick-base/functions/wick-service
+++ b/formulas/wick-base/functions/wick-service
@@ -119,7 +119,7 @@ wickService() {
     # Remove the action from the unparsed items. The IFS setting is required
     # for this to work in bash 3 regardless to the IFS setting.
     # See https://github.com/fidian/gg-core/pull/7
-    IFS= unparsed=("${unparsed[@]:1}")
+    IFS=" " unparsed=("${unparsed[@]:1}")
 
     case "$action" in
         add)


### PR DESCRIPTION
```
>cat testServiceIssue 
#!/usr/bin/env bash

. /usr/local/lib/wick-infect
wickStrictMode

testFunction() {
    wickGetOptions options "$@" || return $?
    wickGetArgument action 0 "$@" || return $?
    wickGetArguments unparsed "$@" || return $?
    if [[ ${#unparsed[@]} -lt 1 ]]; then
        wickError "Specify action to take and the service name to act upon." || return $?

        return 1
    fi

    if [[ ${#unparsed[@]} -lt 2 ]]; then
        wickError "Must specify service name to act upon" || return $?

        return 1
    fi

        unparsedClone=("${unparsed[@]}")
        unparsedClone2=("${unparsed[@]}")
        unparsed=("${unparsed[@]:1}")
        echo "unparsed:" "${unparsed[*]}"
        IFS= unparsedClone=("${unparsedClone[@]:1}")
        echo "unparsedClone:" "${unparsedClone[*]}"
        IFS=" " unparsedClone2=("${unparsedClone2[@]:1}")
        echo "unparsedClone2:" "${unparsedClone2[*]}"


}


testFunction machineName action service
>bash testServiceIssue 
unparsed: action
service
unparsedClone: actionservice
unparsedClone2: action service
>

```