### PR TITLE
Revert "IFS= appears to merge all elements"

### DIFF
--- a/doc/argument-processing.md
+++ b/doc/argument-processing.md
@@ -108,7 +108,7 @@ Imagine a function that will consume one argument and pass the rest to another f
 
         # Remove the first item from the list. The IFS notation is to
         # ensure this works even in bash 3, regardless of IFS settings.
-        IFS=" " ARGS=("${ARGS[@]:1}")
+        IFS= ARGS=("${ARGS[@]:1}")
 
         # Pass the remaining arguments to another function
         setupDir "${ARGS[@]}"

--- a/formulas/wick-base/functions/wick-service
+++ b/formulas/wick-base/functions/wick-service
@@ -119,7 +119,7 @@ wickService() {
     # Remove the action from the unparsed items. The IFS setting is required
     # for this to work in bash 3 regardless to the IFS setting.
     # See https://github.com/fidian/gg-core/pull/7
-    IFS=" " unparsed=("${unparsed[@]:1}")
+    IFS= unparsed=("${unparsed[@]:1}")
 
     case "$action" in
         add)


### PR DESCRIPTION
Reverts tests-always-included/wick#113

I don't think this was adequately tested. I've added these three lines to the end of the sample script.

    set | grep ^unparsed=
    set | grep ^unparsedClone=
    set | grep ^unparsedClone2=

The results say the variables are all arrays.

    unparsed=([0]="action" [1]="service")
    unparsedClone=([0]="action" [1]="service")
    unparsedClone2=([0]="action" [1]="service")

I don't quite get it, but this is certainly not a single string.