### PR TITLE
Adding KV store and hex encoding

### DIFF
--- a/bin/wick-run
+++ b/bin/wick-run
@@ -17,6 +17,12 @@ wickRun() {
         return 1
     fi
 
+    # Set up the KV store. If Wick gets split so the prep work can be done
+    # on one machine and the execution of formulas can be done on a target
+    # machine, the KV store will need to get migrated to the target machine.
+    wickKvInit
+
+    # Run the role.
     wickLoadRole "$@"
 
     if [[ ${#WICK_FORMULA_COMMANDS[@]} -eq 0 ]]; then

--- a/bin/wick-run
+++ b/bin/wick-run
@@ -17,9 +17,8 @@ wickRun() {
         return 1
     fi
 
-    # Set up the KV store. If Wick gets split so the prep work can be done
-    # on one machine and the execution of formulas can be done on a target
-    # machine, the KV store will need to get migrated to the target machine.
+    # Set up the KV store. This must be migrated to the destination machine
+    # when Wick gets split into a provisioner/provisionee model.
     wickKvInit
 
     # Run the role.

--- a/lib/wick-hex
+++ b/lib/wick-hex
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Public: Encode a string as hex.
+#
+# $1 - Destination variable for the hex encoded version of the data.
+# $2 - The string to encode as hex.
+#
+# Returns nothing.
+wickHex() {
+    local c index out
+
+    in="$2"
+    out=
+    index=0
+
+    while [[ "${#in}" -gt "$index" ]]; do
+        c=${in:$index:1}
+        printf -v c "%02x" "'$c"
+        out="$out$c"
+        index=$((index + 1))
+    done
+
+    local "$1" && wickIndirect "$1" "$out"
+}

--- a/lib/wick-kv-get
+++ b/lib/wick-kv-get
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Public: Retrieve a value from the KV store.
+#
+# $1 - Destination variable name.
+# $2 - Key to retrieve.
+#
+# Examples:
+#
+#   wickKvSet test.message "Hi"
+#   wickKvGet MSG test.message
+#   echo "$MSG"  # "Hi"
+#
+# Returns true on succes, 1 if the KV store is not initialized. Does not error
+# if the key is not set.
+wickKvGet() {
+    local key result
+
+    if ! wickKvIsReady; then
+        wickError "KV store not initialized"
+
+        return 1
+    fi
+
+    wickHex key "$2"
+
+    if [[ -f "$WICK_KV_DIR/$key" ]]; then
+        result=$(< "$WICK_KV_DIR/$key")
+    else
+        result="."
+    fi
+
+    result="${result%?}"
+
+    local $1 && wickIndirect "$1" "$result"
+}

--- a/lib/wick-kv-get
+++ b/lib/wick-kv-get
@@ -10,7 +10,7 @@
 #   wickKvGet MSG test.message
 #   echo "$MSG"  # "Hi"
 #
-# Returns true on succes, 1 if the KV store is not initialized. Does not error
+# Returns true on success, 1 if the KV store is not initialized. Does not error
 # if the key is not set.
 wickKvGet() {
     local key result

--- a/lib/wick-kv-init
+++ b/lib/wick-kv-init
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Internal: Creates the KV store and sets the necessary environment variable to
+# the directory where the KV store is located.
+#
+# Examples
+#
+#   wickKvInit
+#
+# Returns nothing.
+wickKvInit() {
+    if wickKvIsReady; then
+        wickDebug "Using existing KV store: $WICK_KV_DIR"
+    else
+        wickDebug "Creating KV store directory"
+        wickTempDir WICK_KV_DIR
+        wickDebug "Created KV store: $WICK_KV_DIR"
+    fi
+}

--- a/lib/wick-kv-is-ready
+++ b/lib/wick-kv-is-ready
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Internal: Checks if the KV store has been initialized.
+#
+# Examples
+#
+#   # Starting with this not ready. Prints "Not ready."
+#   wickKvIsReady || echo "Not ready."
+#
+#   # Initialize
+#   wickKvInit
+#
+#   # Now this is ready. Prints "Ready."
+#   wickKvIsReady && echo "Ready."
+#
+# Returns true if it is ready, anything else if it is not ready.
+wickKvIsReady() {
+    [[ -n "${WICK_KV_DIR-}" && -d "$WICK_KV_DIR" ]]
+}

--- a/lib/wick-kv-is-set
+++ b/lib/wick-kv-is-set
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Public: Check if a key is set in the KV store.
+#
+# $1 - Name of the key.
+#
+# Examples:
+#
+#   # Start with it not set. This prints "Not set."
+#   wickKvIsSet test.message || echo "Not set."
+#
+#   # Assign a value
+#   wickKvSet test.message "Hi"
+#
+#   # Now it exists. Prints "Key is assigned a value."
+#   wickKvIsSet test.message && echo "Key is assigned a value."
+#
+# Returns true when the key exists, false otherwise.
+wickKvIsSet() {
+    local key
+
+    if ! wickKvIsReady; then
+        wickError "KV store not initialized"
+
+        return 1
+    fi
+
+    wickHex key "$1"
+
+    [[ -f "$WICK_KV_DIR/$key" ]]
+}

--- a/lib/wick-kv-set
+++ b/lib/wick-kv-set
@@ -10,7 +10,7 @@
 #   wickKvGet MSG test.message
 #   echo "$MSG"  # "Hi"
 #
-# Returns true on succes, 1 if the KV store is not initialized.
+# Returns true on success, 1 if the KV store is not initialized.
 wickKvSet() {
     local key
 

--- a/lib/wick-kv-set
+++ b/lib/wick-kv-set
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Public: Assigns a value to the KV store.
+#
+# $1 - Key to set.
+# $2 - Value to save.
+#
+# Examples:
+#
+#   wickKvSet test.message "Hi"
+#   wickKvGet MSG test.message
+#   echo "$MSG"  # "Hi"
+#
+# Returns true on succes, 1 if the KV store is not initialized.
+wickKvSet() {
+    local key
+
+    if ! wickKvIsReady; then
+        wickError "KV store not initialized"
+
+        return 1
+    fi
+
+    wickHex key "$1"
+
+    # Adding an extra period here in case there's whitespace in $2.
+    # We want to preserve it. The way we read a file in wickKvGet
+    # would normally destroy the whitespace.
+    echo -n "${2}." > "$WICK_KV_DIR/$key"
+}

--- a/tests/lib/wick-hex.bats
+++ b/tests/lib/wick-hex.bats
@@ -1,0 +1,21 @@
+#!../bats/bats
+
+setup() {
+    load ../wick-test-base
+    . "$WICK_DIR/lib/wick-hex"
+    . "$WICK_DIR/lib/wick-indirect"
+}
+
+@test "lib/wick-hex: empty" {
+    local X
+
+    wickHex X ""
+    [[ "$X" == "" ]]
+}
+
+@test "lib/wick-hex: not empty" {
+    local X
+
+    wickHex X $'abc\n123\n'
+    [[ "$X" == "6162630a3132330a" ]]
+}

--- a/tests/lib/wick-kv.bats
+++ b/tests/lib/wick-kv.bats
@@ -1,0 +1,110 @@
+#!../bats/bats
+
+setup() {
+    load ../wick-test-base
+    . "$WICK_DIR/lib/wick-argument-string"
+    . "$WICK_DIR/lib/wick-debug"
+    . "$WICK_DIR/lib/wick-hex"
+    . "$WICK_DIR/lib/wick-indirect"
+    . "$WICK_DIR/lib/wick-is-var-set"
+    . "$WICK_DIR/lib/wick-kv-get"
+    . "$WICK_DIR/lib/wick-kv-init"
+    . "$WICK_DIR/lib/wick-kv-is-ready"
+    . "$WICK_DIR/lib/wick-kv-is-set"
+    . "$WICK_DIR/lib/wick-kv-set"
+    . "$WICK_DIR/lib/wick-log"
+    . "$WICK_DIR/lib/wick-on-exit"
+    . "$WICK_DIR/lib/wick-on-exit-trap"
+    . "$WICK_DIR/lib/wick-random-string"
+    . "$WICK_DIR/lib/wick-temp-dir"
+}
+
+@test "lib/wick-kv-is-ready: Reports false" {
+    wickKvIsReady || return 0
+    return 1
+}
+
+@test "lib/wick-kv-is-ready: Reports success" {
+    # Subshell so on-exit trap fires
+    (
+        wickKvInit
+        wickKvIsReady
+    )
+}
+
+@test "lib/wick-kv-init: Sets WICK_KV_DIR" {
+    # Subshell so on-exit trap fires
+    (
+        wickIsVarSet WICK_KV_DIR && (
+            echo "Variable should not be set before initialization" >&2
+            return 1
+        )
+
+        wickKvInit
+
+        wickIsVarSet WICK_KV_DIR || (
+            echo "Variable not set" >&2
+            return 1
+        )
+
+        [[ -d "$WICK_KV_DIR" ]] || (
+            echo "Directory not created" >&2
+            return 1
+        )
+    )
+}
+
+@test "lib/wick-kv-is-set: works when vars get set" {
+    # Subshell so on-exit trap fires
+    (
+        wickKvInit
+        wickKvIsSet testing && (
+            echo "Variable should not yet be set" >&2
+            return 1
+        )
+
+        wickKvSet testing "any value"
+        wickKvIsSet testing || (
+            echo "Variable should be set" >&2
+            return 1
+        )
+    )
+}
+
+@test "lib/wick-kv-get: Getting an unset value" {
+    # Subshell so on-exit trap fires
+    (
+        local result
+
+        wickKvInit
+        result="unchanged"
+        wickKvGet result test.key
+        [[ "$result" == "" ]]
+    )
+}
+
+@test "lib/wick-kv-?et: Set and get string" {
+    # Subshell so on-exit trap fires
+    (
+        local result
+
+        wickKvInit
+        wickKvSet test.key "a string"
+        result="unchanged"
+        wickKvGet result test.key
+        [[ "$result" == "a string" ]]
+    )
+}
+
+@test "lib/wick-kv-?et: Set and get whitespace" {
+    # Subshell so on-exit trap fires
+    (
+        local result
+
+        wickKvInit
+        wickKvSet test.key $'1\n2\n'
+        result="unchanged"
+        wickKvGet result test.key
+        [[ "$result" == $'1\n2\n' ]]
+    )
+}


### PR DESCRIPTION
The hex encoding is to make sure we generate valid filenames even if the
KV store is asked to save things that are weird.

    wickKvSet .hidden ""
    wickKvSet ../somewhere/else ""
    wickKvSet /etc/passwd ""

The keys are converted to hex and are stored in the KV folder that's
cleaned up when Wick exits.

This closes #36.