### PR TITLE
Handle certain cases where apt-get asks the user for input

### DIFF
--- a/formulas/update-packages/run
+++ b/formulas/update-packages/run
@@ -53,7 +53,7 @@ case "$OS" in
                 exit 1
             fi
 
-            if DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" apt-get upgrade -y; then
+            if DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" upgrade -y; then
                 tryNumber=100
             fi
         done

--- a/formulas/update-packages/run
+++ b/formulas/update-packages/run
@@ -53,7 +53,7 @@ case "$OS" in
                 exit 1
             fi
 
-            if DEBIAN_FRONTEND=noninteractive apt-get upgrade -y; then
+            if DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::="--force-confdef" apt-get upgrade -y; then
                 tryNumber=100
             fi
         done


### PR DESCRIPTION
Certain packages prompt the user for input. The extra added parameters will instruct apt to just apply the default choice.

NOTE: This is similar to "DEBIAN_FRONTEND=noninteractive" , but not the same. Apparently there are two different systems that can be used to interact with the user during installations and this one makes the second system non-interactive as well