### PR TITLE
fix systemd-resolved <--> dnsmasq loop

### DIFF
--- a/formulas/dnsmasq/run
+++ b/formulas/dnsmasq/run
@@ -69,6 +69,13 @@ if [[ -n "$protectDns" ]]; then
     wickMakeFile protect-dns-resolver-config - | wickAddConfigSection /etc/dhcp/dhclient-enter-hooks protect-dns-resolver-config
 fi
 
+# If systemd-resolved is used we need to this to prevent looping of dns queries.
+if [[ -e "/etc/systemd/resolved.conf" ]]; then
+    if grep -E "^.?DNS=" "/etc/systemd/resolved.conf" &> /dev/null; then
+        sed -i -r -e 's/^.?DNS=.*/DNS=""/' "/etc/systemd/resolved.conf"
+    fi
+fi
+
 # When --start is used, enable dnsmasq.
 if [[ -n "$start" ]]; then
     RESOLV=$(


### PR DESCRIPTION
systemd-resolved uses dns servers found in resolv.conf as well as any it got from dhcp if no DNS is configured in resolved.conf. As we put 127.0.0.1 in resolv.conf to use dnsmasq and it forwards queries not specifically directed elsewhere to systemd-resolved you could get a loop. I've seen it myself, systemd-resolved would use 100% of a core and dnsmaq 60% of another core. Other people seem to have run into similar issues.

e.g. https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1670959