### PR TITLE
setting correct hostname using hostnamectl also

### DIFF
--- a/formulas/hostname/files/set-hostname
+++ b/formulas/hostname/files/set-hostname
@@ -88,6 +88,16 @@ wickDebug "Setting hostname to $full"
 #
 reload=false
 
+if which hostnamectl &> /dev/null; then
+    if [[ "$(hostnamectl status --static)" != "$host" ]]; then
+        hostnamectl set-hostname "$host"
+        reload=true
+    elif [[ "$(hostnamectl status --transient)" != "$host" ]]; then
+        hostnamectl set-hostname "$host"
+        reload=true
+    fi
+fi
+
 if [[ -f /etc/hostname ]]; then
     if [[ "$(cat /etc/hostname)" !=  "$host" ]]; then
         wickDebug "Setting /etc/hostname to $host"


### PR DESCRIPTION
Sometimes for reasons unknown to me a "transient" name was set in hostnamectl and this causes a fight between systemd-resolved and other things trying to set the hostname, as systemd runs many things in parallel it depends which thing runs last to find which hostname you end up with. The addition here will set the hostname using hostnamectl if the command is in the path and it reports either it's static or transient name as different from desired.